### PR TITLE
Fix tmux integration

### DIFF
--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -81,7 +81,7 @@ def iterfzf(
     if preview:
         cmd.append('--preview=' + preview)
     if tmux:
-        cmd.append('--tmux' if tmux is bool else f'--tmux={tmux}')
+        cmd.append('--tmux' if type(tmux) is bool else f'--tmux={tmux}')
     if header:
         cmd.append('--header=' + header)
     if ansi:

--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -81,7 +81,7 @@ def iterfzf(
     if preview:
         cmd.append('--preview=' + preview)
     if tmux:
-        cmd.append('--tmux' if type(tmux) is bool else f'--tmux={tmux}')
+        cmd.append('--tmux' if tmux is True else f'--tmux={tmux}')
     if header:
         cmd.append('--header=' + header)
     if ansi:


### PR DESCRIPTION
# Description

The iterfzf function encounters an error when invoked with the `tmux=True` option, resulting in the following error message:
```
invalid tmux option: True (expected: [center|top|bottom|left|right][,SIZE[%]][,SIZE[%][,border-native]])
```

The issue arises from an incorrect parameter type check, resulting in the addition of the `--tmux=True` option to the command string, which is not a valid parameter for `fzf`.
